### PR TITLE
Add route to update PlayerToon remnants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swgu-nest",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "The swgu-nest is the back-end server powering the Star Wars Galaxy Ultimate game",
   "author": "swgu",
   "private": true,

--- a/src/base/auth/auth.controller.ts
+++ b/src/base/auth/auth.controller.ts
@@ -40,8 +40,6 @@ export class AuthController {
   async refreshTokens(@Request() req: any) {
     const userId = req.user['sub'];
     const refreshToken = req.user['refreshToken'];
-    console.log('userId: ', userId);
-    console.log('refreshToken: ', refreshToken);
     return await this.authService.refreshTokens(userId, refreshToken);
   }
 }

--- a/src/base/auth/auth.service.ts
+++ b/src/base/auth/auth.service.ts
@@ -51,8 +51,6 @@ export class AuthService {
       throw new BadRequestException('Player already exists');
     }
 
-    console.log('attempting to create player 2: ', createPlayerDto);
-
     const newPlayer = await this.playersService.createPlayer(createPlayerDto);
     const tokens = await this.getTokens(newPlayer._id, newPlayer.username);
     await this.updateRefreshToken(newPlayer._id, tokens.refreshToken);

--- a/src/base/auth/strategies/local.strategy.ts
+++ b/src/base/auth/strategies/local.strategy.ts
@@ -10,7 +10,6 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(username: string, password: string) {
-    console.log('validating info from request', username, password);
     const user = await this.authService.validateUser(username, password);
     if (!user) {
       return new UnauthorizedException();

--- a/src/base/player-toon/player-toon.controller.ts
+++ b/src/base/player-toon/player-toon.controller.ts
@@ -7,7 +7,7 @@ import {
   Get,
   Delete,
   Param,
-  Query,
+  Patch,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { PlayerToonsService } from './player-toon.service';
@@ -32,10 +32,23 @@ export class PlayerToonsController {
   @Get('/:playerToonId/upgradeByStar')
   async upgradeByStar(
     @Param('playerToonId') playerToonId: string,
-    @Query('remnants') remnants: number,
     @Request() req: any,
   ) {
     return await this.playerToonsService.upgradeByStar(
+      playerToonId,
+      req.user.userId,
+    );
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id')
+  async updatePlayerToon(
+    @Param('id') playerToonId: string,
+    @Body('remnants') remnants: number,
+    @Request() req: any,
+  ) {
+    console.log(`Attempting to update playerToon ${playerToonId}`);
+    return await this.playerToonsService.updatePlayerToon(
       playerToonId,
       remnants,
       req.user.userId,

--- a/src/base/player-toon/util/star-mapper.ts
+++ b/src/base/player-toon/util/star-mapper.ts
@@ -156,8 +156,19 @@ const StarMapper = [
   },
 ];
 
-const getStarMapper = () => {
+export const getStarMapper = () => {
   return StarMapper;
 };
 
-export default getStarMapper;
+export const playerShouldLevelUp = (
+  currentPlayerStars: number,
+  currentPlayerRemnants: number,
+) => {
+  const currentStarMapObject = getStarMapper().filter(
+    (obj) => obj.stars === currentPlayerStars + 1,
+  );
+  if (currentStarMapObject && currentStarMapObject.length === 1) {
+    const currentStarMapObjectRemnants = currentStarMapObject[0].remnants;
+    return currentPlayerRemnants >= currentStarMapObjectRemnants ? true : false;
+  }
+};

--- a/src/base/player/player.service.ts
+++ b/src/base/player/player.service.ts
@@ -124,7 +124,6 @@ export class PlayersService {
         }
         throw new NotFoundException('Player Not Found');
       }
-      console.log(`Found a player by username: ${username}`);
       return player;
     } catch (error) {
       this.handleError(error);
@@ -185,7 +184,6 @@ export class PlayersService {
     }
     if (password) {
       player.password = await this.hashData(password);
-      //console.log(`Updated user pwd with hash of ${player.password}`);
     }
     player.save();
     return this.successResponse(`Updated player ${id} successfully`);

--- a/src/base/toons/toonDTO.ts
+++ b/src/base/toons/toonDTO.ts
@@ -2,7 +2,7 @@ import { Optional } from '@nestjs/common';
 import { ToonMedia } from 'src/objects/toon_media';
 import { ToonStats } from 'src/objects/toon_stats';
 import { Ability } from '../abilities/ability.schema';
-import getStarMapper from '../player-toon/util/star-mapper';
+import { getStarMapper } from '../player-toon/util/star-mapper';
 
 /* Defines The following
     BaseToonDTO

--- a/src/base/toons/toons.service.ts
+++ b/src/base/toons/toons.service.ts
@@ -47,7 +47,6 @@ export class ToonsService {
       if (!toon) {
         throw new NotFoundException('Toon Not Found');
       }
-      console.log(`Found a toon by uniqueName: ${uniqueName}`);
       return toon;
     } catch (error) {
       this.handleError(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function bootstrap() {
   });
   await app.listen(process.env.PORT || 8080);
 
-  // Prevent app from going to sleep on Heroku
+  // Prevent app from going to sleep
   // setInterval(async () => {
   //   await axios.get('https://swgu-nest.herokuapp.com/');
   //   console.log('App Pinged');


### PR DESCRIPTION
Updates v0.0.32
 - Added a route to update a PlayerToons Remnants(does not affect star level even if remnantCount is beyond a levels threshold.
 - Added a helper method in the StarMapper to determine if a PlayerToon is able to LevelUp or not.
 - Removed the remnant QP from the `upgradeByStar` route as it is not needed.
 - Removed many unnecessary loggers throughout 